### PR TITLE
Changed default value of loop option in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ superplaceholder({
 		// should start on input focus. Set false to autostart
 		startOnFocus: true,
 		// loop through passed sentences
-		loop: true,
+		loop: false,
 		// Initially shuffle the passed sentences
 		shuffle: false,
 		// Show cursor or not. Shows by default


### PR DESCRIPTION
The loop property defaults to `false` while the readme said that `true` is the default.
