### PR TITLE
add laxbreak jshint rule

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,7 +16,8 @@ module.exports = function(grunt) {
       files: ['Gruntfile.js', 'src/<%= pkg.name %>.js'],
       options: {
         browser: true,
-        devel: true
+        devel: true,
+        laxbreak: true
       }
     },
     uglify: {


### PR DESCRIPTION
Add laxbreak jshint rule to ignore some of the opinionated formatting Prettier does

to fix Issue "Build aborts due to warnings #15"

https://github.com/chinchang/superplaceholder.js/issues/15