### PR TITLE
stop-on-focus

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -156,7 +156,7 @@
 		</footer>
 		<script src="src/superplaceholder.js"></script>
 		<script>
-		superplaceholder({
+		superplaceholder.new({
 			el: inp1,
 			sentences: [ 'Only company emails', 'kushagra@wingify.com', 'adam@google.com' ],
 			options: {
@@ -164,7 +164,7 @@
 			}
 		})
 
-		superplaceholder({
+		superplaceholder.new({
 			el: inp2,
 			sentences: [ '1 special character', '1 uppercase alphabet', 'Eg. hjhhjAsasd*' ],
 			options: {
@@ -173,13 +173,13 @@
 			}
 		})
 
-		superplaceholder({
+		superplaceholder.new({
 			el: inp3,
 			sentences: [ 'Any format works', 'http://yahoo.com', 'www.facebook.com', 'airbnb.com' ],
 			options: {
 				letterDelay: 80,
 				loop: true,
-				startOnFocus: false
+				onFocusBehavior: superplaceholder.FocusBehavior.DO_NOTHING
 			}
 		})
 		</script>

--- a/src/superplaceholder.js
+++ b/src/superplaceholder.js
@@ -15,7 +15,7 @@
     letterDelay: 100, //milliseconds
     sentenceDelay: 1000, //milliseconds
     loop: false,
-    startOnFocus: true,
+    onFocusBehavior: 1,
     shuffle: false,
     showCursor: true,
     cursor: '|'
@@ -45,12 +45,23 @@
       }
     }
 
-    if (self.options.startOnFocus) {
+    if (self.options.onFocusBehavior && self.options.onFocusBehavior === 1) {
       self.el.addEventListener('focus', function() {
         self.processText(0);
       });
       self.el.addEventListener('blur', function() {
         self.cleanUp();
+      });
+    } else if (
+      self.options.onFocusBehavior &&
+      self.options.onFocusBehavior === 2
+    ) {
+      self.processText(0);
+      self.el.addEventListener('focus', function() {
+        self.cleanUp();
+      });
+      self.el.addEventListener('blur', function() {
+        self.processText(0);
       });
     } else {
       self.processText(0);
@@ -112,11 +123,14 @@
     });
   };
 
-  var superplaceholder = function(params) {
-    if (!isPlaceHolderSupported) {
-      return;
-    }
-    new PlaceHolder(params.el, params.sentences, params.options);
+  var superplaceholder = {
+    new: function(params) {
+      if (!isPlaceHolderSupported) {
+        return;
+      }
+      new PlaceHolder(params.el, params.sentences, params.options);
+    },
+    FocusBehavior: Object.freeze({ START: 1, STOP: 2, DO_NOTHING: 3 })
   };
 
   // open to the world.


### PR DESCRIPTION
I wanted the animation to stop on focus so I made this change. This is a breaking change and not the best implementation so feel free to bin this PR. Still I think this would be a useful option to have.

because it would have been weird to have both “startOnFocus” and “stopOnFocus” (you would have to pick one if they where both set to true) in the options i’ve changed the setting to ‘onFocusBehavior’

![superplaceholder_small](https://user-images.githubusercontent.com/2782730/46488747-806ac600-c7fb-11e8-98cd-2433a88eb331.gif)
